### PR TITLE
Deleting a user with a profile causes a fatal error

### DIFF
--- a/decoupled_auth.module
+++ b/decoupled_auth.module
@@ -248,7 +248,12 @@ function decoupled_auth_profile_update(ProfileInterface $entity) {
  * Implements hook_ENTITY_TYPE_delete() for profile.
  */
 function decoupled_auth_profile_delete(ProfileInterface $entity) {
-  $entity->getOwner()->updateProfileFields([$entity->bundle()]);
+  // As we may be deleting in response to a deleted user, check the owner exists
+  // before attempting to update the profile fields.
+  $owner = $entity->getOwner();
+  if ($owner) {
+    $owner->updateProfileFields([$entity->bundle()]);
+  }
 }
 
 /**

--- a/tests/src/Kernel/UserProfileFieldTest.php
+++ b/tests/src/Kernel/UserProfileFieldTest.php
@@ -207,6 +207,30 @@ class UserProfileFieldTest extends KernelTestBase {
   }
 
   /**
+   * Test that the delete operation on a profile via a user deletion.
+   */
+  public function testFieldDeleteUser() {
+    $this->installProfile();
+    $this->enableModules(['decoupled_auth_profile_test']);
+    $this->installConfig(['decoupled_auth_profile_test']);
+
+    // Create our user.
+    $user = $this->createUser();
+
+    // Create the profile.
+    $profile = $this->createProfile('test_single', $user, TURE);
+
+    // Check that the field has been filled out correctly.
+    $user = User::load($user->id());
+    $this->assertEquals($profile->id(), $user->profile_test_single->target_id, 'Test single profile has been stored on the user.');
+    $this->assertInstanceOf(get_class($profile), $user->profile_test_single->entity, 'Test single profile is accessible from the user.');
+    $this->assertEquals($profile->test_field->value, $user->profile_test_single->entity->test_field->value, 'Test single profile test field matches.');
+
+    // Delete the user.
+    $user->delete();
+  }
+
+  /**
    * Test that CRUD operations on a profile updates the appropriate field.
    */
   public function testFieldPopulationMultiple() {

--- a/tests/src/Kernel/UserProfileFieldTest.php
+++ b/tests/src/Kernel/UserProfileFieldTest.php
@@ -210,6 +210,7 @@ class UserProfileFieldTest extends KernelTestBase {
    * Test that the delete operation on a profile via a user deletion.
    */
   public function testFieldDeleteUser() {
+    $this->installSchema('user', 'users_data');
     $this->installProfile();
     $this->enableModules(['decoupled_auth_profile_test']);
     $this->installConfig(['decoupled_auth_profile_test']);
@@ -218,7 +219,7 @@ class UserProfileFieldTest extends KernelTestBase {
     $user = $this->createUser();
 
     // Create the profile.
-    $profile = $this->createProfile('test_single', $user, TURE);
+    $profile = $this->createProfile('test_single', $user, TRUE);
 
     // Check that the field has been filled out correctly.
     $user = User::load($user->id());


### PR DESCRIPTION
The profile delete hook assumes the user exists, but can be triggered by the deletion of a user.